### PR TITLE
add-codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+* @grafana/k6-cloud-provisioning
+


### PR DESCRIPTION
Adds CODEOWNERS file. Assigns ownership of this repository to @grafana/k6-cloud-provisioning.