### PR TITLE
Reset request body before retrying in callAPI

### DIFF
--- a/k6/callapi_retry_test.go
+++ b/k6/callapi_retry_test.go
@@ -1,0 +1,62 @@
+package k6
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestCallAPI_RetryReplaysBody verifies that callAPI restores the request body
+// before retrying. The server fails the first attempt with 503 + Connection:
+// close (as in the production incident this fixes); without the body reset the
+// retry goes out with a drained body and fails with
+// "http: ContentLength=N with Body length 0".
+func TestCallAPI_RetryReplaysBody(t *testing.T) {
+	const payload = "hello-body"
+
+	var attempts int
+	var gotBodies []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		b, _ := io.ReadAll(r.Body)
+		gotBodies = append(gotBodies, string(b))
+		if attempts == 1 {
+			w.Header().Set("Connection", "close")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg := NewConfiguration()
+	cfg.HTTPClient = srv.Client()
+	cfg.MaxRetries = 3
+	cfg.RetryInterval = time.Millisecond
+	c := NewAPIClient(cfg)
+
+	req, err := http.NewRequest(http.MethodPost, srv.URL, strings.NewReader(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.ContentLength = int64(len(payload))
+
+	resp, err := c.callAPI(req)
+	if err != nil {
+		t.Fatalf("callAPI returned error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 after retry, got %d", resp.StatusCode)
+	}
+	if attempts != 2 {
+		t.Fatalf("expected 2 attempts, got %d", attempts)
+	}
+	for i, b := range gotBodies {
+		if b != payload {
+			t.Fatalf("attempt %d received body %q, want %q", i+1, b, payload)
+		}
+	}
+}

--- a/k6/client.go
+++ b/k6/client.go
@@ -275,6 +275,17 @@ func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 	var resp *http.Response
 	var err error
 	for i := 0; i <= c.cfg.MaxRetries; i++ {
+		// http.Client.Do consumes request.Body as it sends the request, so on
+		// any retry we must reset it to a fresh reader. GetBody is non-nil only
+		// when the body is rewindable; leave streaming bodies untouched.
+		if i > 0 && request.GetBody != nil {
+			body, bodyErr := request.GetBody()
+			if bodyErr != nil {
+				return resp, bodyErr
+			}
+			request.Body = body
+		}
+
 		resp, err = c.cfg.HTTPClient.Do(request)
 		if shouldRetry(resp, err, i, c.cfg.MaxRetries) {
 			if c.cfg.Debug {

--- a/templates/client.mustache
+++ b/templates/client.mustache
@@ -269,6 +269,17 @@ func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 	var resp *http.Response
 	var err error
 	for i := 0; i <= c.cfg.MaxRetries; i++ {
+		// http.Client.Do consumes request.Body as it sends the request, so on
+		// any retry we must reset it to a fresh reader. GetBody is non-nil only
+		// when the body is rewindable; leave streaming bodies untouched.
+		if i > 0 && request.GetBody != nil {
+			body, bodyErr := request.GetBody()
+			if bodyErr != nil {
+				return resp, bodyErr
+			}
+			request.Body = body
+		}
+
 		resp, err = c.cfg.HTTPClient.Do(request)
 		if shouldRetry(resp, err, i, c.cfg.MaxRetries) {
 			if c.cfg.Debug {


### PR DESCRIPTION
## Problem

`callAPI`'s retry loop re-calls `HTTPClient.Do` on the **same** `*http.Request` for every attempt. `http.Client.Do` consumes `request.Body` as it sends the request, and the server may close the connection after a retryable response (e.g. 5xx / 429 with `Connection: close`). The loop never restored the body, so the 2nd+ attempt went out with a drained body — silently truncated, or failing outright with `http: ContentLength=N with Body length 0`.

This affects **every** consumer of the SDK issuing a body-carrying request (POST/PUT) that hits a retryable condition — it is not specific to any downstream project.

## Fix

In `templates/client.mustache` (the custom OpenAPI Generator template that produces `callAPI`), reset the body from `request.GetBody()` before each retry:

```go
if i > 0 && request.GetBody != nil {
    body, bodyErr := request.GetBody()
    if bodyErr != nil {
        return resp, bodyErr
    }
    request.Body = body
}
```

Guarded on `i > 0` (happy path untouched) and `GetBody != nil` (streaming/unrewindable bodies untouched). `k6/client.go` regenerated from the template.

## Test

Adds `k6/callapi_retry_test.go`: a `503` + `Connection: close` on the first attempt. Without the fix it reproduces the exact production error (`ContentLength=10 with Body length 0`); with the fix both attempts receive the full body and the retry succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)