### PR TITLE
Widen X-Stack-Id header parameter from int32 to int64

### DIFF
--- a/k6/api_labels.go
+++ b/k6/api_labels.go
@@ -26,12 +26,12 @@ type LabelsAPIService service
 type ApiLabelsCreateRequest struct {
 	ctx                   context.Context
 	ApiService            *LabelsAPIService
-	xStackId              *int32
+	xStackId              *int64
 	labelKeyCreateRequest *LabelKeyCreateRequest
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiLabelsCreateRequest) XStackId(xStackId int32) *ApiLabelsCreateRequest {
+func (r *ApiLabelsCreateRequest) XStackId(xStackId int64) *ApiLabelsCreateRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -205,12 +205,12 @@ func (a *LabelsAPIService) LabelsCreateExecute(r *ApiLabelsCreateRequest) (*Labe
 type ApiLabelsDestroyRequest struct {
 	ctx        context.Context
 	ApiService *LabelsAPIService
-	xStackId   *int32
+	xStackId   *int64
 	id         int64
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiLabelsDestroyRequest) XStackId(xStackId int32) *ApiLabelsDestroyRequest {
+func (r *ApiLabelsDestroyRequest) XStackId(xStackId int64) *ApiLabelsDestroyRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -354,11 +354,11 @@ func (a *LabelsAPIService) LabelsDestroyExecute(r *ApiLabelsDestroyRequest) (*ht
 type ApiLabelsListRequest struct {
 	ctx        context.Context
 	ApiService *LabelsAPIService
-	xStackId   *int32
+	xStackId   *int64
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiLabelsListRequest) XStackId(xStackId int32) *ApiLabelsListRequest {
+func (r *ApiLabelsListRequest) XStackId(xStackId int64) *ApiLabelsListRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -497,13 +497,13 @@ func (a *LabelsAPIService) LabelsListExecute(r *ApiLabelsListRequest) (*LabelKey
 type ApiLabelsPartialUpdateRequest struct {
 	ctx                  context.Context
 	ApiService           *LabelsAPIService
-	xStackId             *int32
+	xStackId             *int64
 	id                   int64
 	labelKeyPatchRequest *LabelKeyPatchRequest
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiLabelsPartialUpdateRequest) XStackId(xStackId int32) *ApiLabelsPartialUpdateRequest {
+func (r *ApiLabelsPartialUpdateRequest) XStackId(xStackId int64) *ApiLabelsPartialUpdateRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -685,13 +685,13 @@ func (a *LabelsAPIService) LabelsPartialUpdateExecute(r *ApiLabelsPartialUpdateR
 type ApiProjectsLabelsDestroyRequest struct {
 	ctx        context.Context
 	ApiService *LabelsAPIService
-	xStackId   *int32
+	xStackId   *int64
 	key        string
 	projectId  int64
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiProjectsLabelsDestroyRequest) XStackId(xStackId int32) *ApiProjectsLabelsDestroyRequest {
+func (r *ApiProjectsLabelsDestroyRequest) XStackId(xStackId int64) *ApiProjectsLabelsDestroyRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -835,12 +835,12 @@ func (a *LabelsAPIService) ProjectsLabelsDestroyExecute(r *ApiProjectsLabelsDest
 type ApiProjectsLabelsListRequest struct {
 	ctx        context.Context
 	ApiService *LabelsAPIService
-	xStackId   *int32
+	xStackId   *int64
 	projectId  int64
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiProjectsLabelsListRequest) XStackId(xStackId int32) *ApiProjectsLabelsListRequest {
+func (r *ApiProjectsLabelsListRequest) XStackId(xStackId int64) *ApiProjectsLabelsListRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -993,13 +993,13 @@ func (a *LabelsAPIService) ProjectsLabelsListExecute(r *ApiProjectsLabelsListReq
 type ApiProjectsLabelsUpdateRequest struct {
 	ctx                    context.Context
 	ApiService             *LabelsAPIService
-	xStackId               *int32
+	xStackId               *int64
 	projectId              int64
 	projectLabelPutRequest *ProjectLabelPutRequest
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiProjectsLabelsUpdateRequest) XStackId(xStackId int32) *ApiProjectsLabelsUpdateRequest {
+func (r *ApiProjectsLabelsUpdateRequest) XStackId(xStackId int64) *ApiProjectsLabelsUpdateRequest {
 	r.xStackId = &xStackId
 	return r
 }

--- a/k6/api_load_tests.go
+++ b/k6/api_load_tests.go
@@ -27,12 +27,12 @@ type LoadTestsAPIService service
 type ApiLoadTestsDestroyRequest struct {
 	ctx        context.Context
 	ApiService *LoadTestsAPIService
-	xStackId   *int32
+	xStackId   *int64
 	id         int64
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiLoadTestsDestroyRequest) XStackId(xStackId int32) *ApiLoadTestsDestroyRequest {
+func (r *ApiLoadTestsDestroyRequest) XStackId(xStackId int64) *ApiLoadTestsDestroyRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -184,7 +184,7 @@ func (a *LoadTestsAPIService) LoadTestsDestroyExecute(r *ApiLoadTestsDestroyRequ
 type ApiLoadTestsListRequest struct {
 	ctx        context.Context
 	ApiService *LoadTestsAPIService
-	xStackId   *int32
+	xStackId   *int64
 	count      *bool
 	orderby    *string
 	skip       *int32
@@ -193,7 +193,7 @@ type ApiLoadTestsListRequest struct {
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiLoadTestsListRequest) XStackId(xStackId int32) *ApiLoadTestsListRequest {
+func (r *ApiLoadTestsListRequest) XStackId(xStackId int64) *ApiLoadTestsListRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -391,13 +391,13 @@ func (a *LoadTestsAPIService) LoadTestsListExecute(r *ApiLoadTestsListRequest) (
 type ApiLoadTestsMoveRequest struct {
 	ctx                  context.Context
 	ApiService           *LoadTestsAPIService
-	xStackId             *int32
+	xStackId             *int64
 	id                   int64
 	moveLoadTestApiModel *MoveLoadTestApiModel
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiLoadTestsMoveRequest) XStackId(xStackId int32) *ApiLoadTestsMoveRequest {
+func (r *ApiLoadTestsMoveRequest) XStackId(xStackId int64) *ApiLoadTestsMoveRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -571,13 +571,13 @@ func (a *LoadTestsAPIService) LoadTestsMoveExecute(r *ApiLoadTestsMoveRequest) (
 type ApiLoadTestsPartialUpdateRequest struct {
 	ctx                   context.Context
 	ApiService            *LoadTestsAPIService
-	xStackId              *int32
+	xStackId              *int64
 	id                    int64
 	patchLoadTestApiModel *PatchLoadTestApiModel
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiLoadTestsPartialUpdateRequest) XStackId(xStackId int32) *ApiLoadTestsPartialUpdateRequest {
+func (r *ApiLoadTestsPartialUpdateRequest) XStackId(xStackId int64) *ApiLoadTestsPartialUpdateRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -747,12 +747,12 @@ func (a *LoadTestsAPIService) LoadTestsPartialUpdateExecute(r *ApiLoadTestsParti
 type ApiLoadTestsRetrieveRequest struct {
 	ctx        context.Context
 	ApiService *LoadTestsAPIService
-	xStackId   *int32
+	xStackId   *int64
 	id         int64
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiLoadTestsRetrieveRequest) XStackId(xStackId int32) *ApiLoadTestsRetrieveRequest {
+func (r *ApiLoadTestsRetrieveRequest) XStackId(xStackId int64) *ApiLoadTestsRetrieveRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -905,12 +905,12 @@ func (a *LoadTestsAPIService) LoadTestsRetrieveExecute(r *ApiLoadTestsRetrieveRe
 type ApiLoadTestsScriptRetrieveRequest struct {
 	ctx        context.Context
 	ApiService *LoadTestsAPIService
-	xStackId   *int32
+	xStackId   *int64
 	id         int64
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiLoadTestsScriptRetrieveRequest) XStackId(xStackId int32) *ApiLoadTestsScriptRetrieveRequest {
+func (r *ApiLoadTestsScriptRetrieveRequest) XStackId(xStackId int64) *ApiLoadTestsScriptRetrieveRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -1077,13 +1077,13 @@ func (a *LoadTestsAPIService) LoadTestsScriptRetrieveExecute(r *ApiLoadTestsScri
 type ApiLoadTestsScriptUpdateRequest struct {
 	ctx        context.Context
 	ApiService *LoadTestsAPIService
-	xStackId   *int32
+	xStackId   *int64
 	id         int64
 	body       io.ReadCloser
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiLoadTestsScriptUpdateRequest) XStackId(xStackId int32) *ApiLoadTestsScriptUpdateRequest {
+func (r *ApiLoadTestsScriptUpdateRequest) XStackId(xStackId int64) *ApiLoadTestsScriptUpdateRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -1246,13 +1246,13 @@ func (a *LoadTestsAPIService) LoadTestsScriptUpdateExecute(r *ApiLoadTestsScript
 type ApiLoadTestsStartRequest struct {
 	ctx              context.Context
 	ApiService       *LoadTestsAPIService
-	xStackId         *int32
+	xStackId         *int64
 	id               int64
 	k6IdempotencyKey *string
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiLoadTestsStartRequest) XStackId(xStackId int32) *ApiLoadTestsStartRequest {
+func (r *ApiLoadTestsStartRequest) XStackId(xStackId int64) *ApiLoadTestsStartRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -1414,7 +1414,7 @@ func (a *LoadTestsAPIService) LoadTestsStartExecute(r *ApiLoadTestsStartRequest)
 type ApiProjectsLoadTestsCreateRequest struct {
 	ctx        context.Context
 	ApiService *LoadTestsAPIService
-	xStackId   *int32
+	xStackId   *int64
 	id         int64
 	name       *string
 	script     io.ReadCloser
@@ -1422,7 +1422,7 @@ type ApiProjectsLoadTestsCreateRequest struct {
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiProjectsLoadTestsCreateRequest) XStackId(xStackId int32) *ApiProjectsLoadTestsCreateRequest {
+func (r *ApiProjectsLoadTestsCreateRequest) XStackId(xStackId int64) *ApiProjectsLoadTestsCreateRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -1654,7 +1654,7 @@ func (a *LoadTestsAPIService) ProjectsLoadTestsCreateExecute(r *ApiProjectsLoadT
 type ApiProjectsLoadTestsRetrieveRequest struct {
 	ctx        context.Context
 	ApiService *LoadTestsAPIService
-	xStackId   *int32
+	xStackId   *int64
 	id         int64
 	count      *bool
 	orderby    *string
@@ -1664,7 +1664,7 @@ type ApiProjectsLoadTestsRetrieveRequest struct {
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiProjectsLoadTestsRetrieveRequest) XStackId(xStackId int32) *ApiProjectsLoadTestsRetrieveRequest {
+func (r *ApiProjectsLoadTestsRetrieveRequest) XStackId(xStackId int64) *ApiProjectsLoadTestsRetrieveRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -1876,12 +1876,12 @@ func (a *LoadTestsAPIService) ProjectsLoadTestsRetrieveExecute(r *ApiProjectsLoa
 type ApiValidateOptionsRequest struct {
 	ctx                    context.Context
 	ApiService             *LoadTestsAPIService
-	xStackId               *int32
+	xStackId               *int64
 	validateOptionsRequest *ValidateOptionsRequest
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiValidateOptionsRequest) XStackId(xStackId int32) *ApiValidateOptionsRequest {
+func (r *ApiValidateOptionsRequest) XStackId(xStackId int64) *ApiValidateOptionsRequest {
 	r.xStackId = &xStackId
 	return r
 }

--- a/k6/api_load_zones.go
+++ b/k6/api_load_zones.go
@@ -26,12 +26,12 @@ type LoadZonesAPIService service
 type ApiLoadZonesAllowedProjectsRetrieveRequest struct {
 	ctx        context.Context
 	ApiService *LoadZonesAPIService
-	xStackId   *int32
+	xStackId   *int64
 	id         int64
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiLoadZonesAllowedProjectsRetrieveRequest) XStackId(xStackId int32) *ApiLoadZonesAllowedProjectsRetrieveRequest {
+func (r *ApiLoadZonesAllowedProjectsRetrieveRequest) XStackId(xStackId int64) *ApiLoadZonesAllowedProjectsRetrieveRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -184,13 +184,13 @@ func (a *LoadZonesAPIService) LoadZonesAllowedProjectsRetrieveExecute(r *ApiLoad
 type ApiLoadZonesAllowedProjectsUpdateRequest struct {
 	ctx                               context.Context
 	ApiService                        *LoadZonesAPIService
-	xStackId                          *int32
+	xStackId                          *int64
 	id                                int64
 	updateAllowedProjectsListApiModel *UpdateAllowedProjectsListApiModel
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiLoadZonesAllowedProjectsUpdateRequest) XStackId(xStackId int32) *ApiLoadZonesAllowedProjectsUpdateRequest {
+func (r *ApiLoadZonesAllowedProjectsUpdateRequest) XStackId(xStackId int64) *ApiLoadZonesAllowedProjectsUpdateRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -364,12 +364,12 @@ func (a *LoadZonesAPIService) LoadZonesAllowedProjectsUpdateExecute(r *ApiLoadZo
 type ApiLoadZonesListRequest struct {
 	ctx          context.Context
 	ApiService   *LoadZonesAPIService
-	xStackId     *int32
+	xStackId     *int64
 	k6LoadZoneId *string
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiLoadZonesListRequest) XStackId(xStackId int32) *ApiLoadZonesListRequest {
+func (r *ApiLoadZonesListRequest) XStackId(xStackId int64) *ApiLoadZonesListRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -528,12 +528,12 @@ func (a *LoadZonesAPIService) LoadZonesListExecute(r *ApiLoadZonesListRequest) (
 type ApiProjectsAllowedLoadZonesRetrieveRequest struct {
 	ctx        context.Context
 	ApiService *LoadZonesAPIService
-	xStackId   *int32
+	xStackId   *int64
 	id         int64
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiProjectsAllowedLoadZonesRetrieveRequest) XStackId(xStackId int32) *ApiProjectsAllowedLoadZonesRetrieveRequest {
+func (r *ApiProjectsAllowedLoadZonesRetrieveRequest) XStackId(xStackId int64) *ApiProjectsAllowedLoadZonesRetrieveRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -686,13 +686,13 @@ func (a *LoadZonesAPIService) ProjectsAllowedLoadZonesRetrieveExecute(r *ApiProj
 type ApiProjectsAllowedLoadZonesUpdateRequest struct {
 	ctx                                context.Context
 	ApiService                         *LoadZonesAPIService
-	xStackId                           *int32
+	xStackId                           *int64
 	id                                 int64
 	updateAllowedLoadZonesListApiModel *UpdateAllowedLoadZonesListApiModel
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiProjectsAllowedLoadZonesUpdateRequest) XStackId(xStackId int32) *ApiProjectsAllowedLoadZonesUpdateRequest {
+func (r *ApiProjectsAllowedLoadZonesUpdateRequest) XStackId(xStackId int64) *ApiProjectsAllowedLoadZonesUpdateRequest {
 	r.xStackId = &xStackId
 	return r
 }

--- a/k6/api_projects.go
+++ b/k6/api_projects.go
@@ -27,7 +27,7 @@ type ProjectsAPIService service
 type ApiProjectLimitsRetrieveRequest struct {
 	ctx         context.Context
 	ApiService  *ProjectsAPIService
-	xStackId    *int32
+	xStackId    *int64
 	count       *bool
 	skip        *int32
 	top         *int32
@@ -35,7 +35,7 @@ type ApiProjectLimitsRetrieveRequest struct {
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiProjectLimitsRetrieveRequest) XStackId(xStackId int32) *ApiProjectLimitsRetrieveRequest {
+func (r *ApiProjectLimitsRetrieveRequest) XStackId(xStackId int64) *ApiProjectLimitsRetrieveRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -232,12 +232,12 @@ func (a *ProjectsAPIService) ProjectLimitsRetrieveExecute(r *ApiProjectLimitsRet
 type ApiProjectsCreateRequest struct {
 	ctx                   context.Context
 	ApiService            *ProjectsAPIService
-	xStackId              *int32
+	xStackId              *int64
 	createProjectApiModel *CreateProjectApiModel
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiProjectsCreateRequest) XStackId(xStackId int32) *ApiProjectsCreateRequest {
+func (r *ApiProjectsCreateRequest) XStackId(xStackId int64) *ApiProjectsCreateRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -408,12 +408,12 @@ func (a *ProjectsAPIService) ProjectsCreateExecute(r *ApiProjectsCreateRequest) 
 type ApiProjectsDestroyRequest struct {
 	ctx        context.Context
 	ApiService *ProjectsAPIService
-	xStackId   *int32
+	xStackId   *int64
 	id         int64
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiProjectsDestroyRequest) XStackId(xStackId int32) *ApiProjectsDestroyRequest {
+func (r *ApiProjectsDestroyRequest) XStackId(xStackId int64) *ApiProjectsDestroyRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -565,13 +565,13 @@ func (a *ProjectsAPIService) ProjectsDestroyExecute(r *ApiProjectsDestroyRequest
 type ApiProjectsLimitsPartialUpdateRequest struct {
 	ctx                       context.Context
 	ApiService                *ProjectsAPIService
-	xStackId                  *int32
+	xStackId                  *int64
 	id                        int64
 	patchProjectLimitsRequest *PatchProjectLimitsRequest
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiProjectsLimitsPartialUpdateRequest) XStackId(xStackId int32) *ApiProjectsLimitsPartialUpdateRequest {
+func (r *ApiProjectsLimitsPartialUpdateRequest) XStackId(xStackId int64) *ApiProjectsLimitsPartialUpdateRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -732,12 +732,12 @@ func (a *ProjectsAPIService) ProjectsLimitsPartialUpdateExecute(r *ApiProjectsLi
 type ApiProjectsLimitsRetrieveRequest struct {
 	ctx        context.Context
 	ApiService *ProjectsAPIService
-	xStackId   *int32
+	xStackId   *int64
 	id         int64
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiProjectsLimitsRetrieveRequest) XStackId(xStackId int32) *ApiProjectsLimitsRetrieveRequest {
+func (r *ApiProjectsLimitsRetrieveRequest) XStackId(xStackId int64) *ApiProjectsLimitsRetrieveRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -890,7 +890,7 @@ func (a *ProjectsAPIService) ProjectsLimitsRetrieveExecute(r *ApiProjectsLimitsR
 type ApiProjectsListRequest struct {
 	ctx        context.Context
 	ApiService *ProjectsAPIService
-	xStackId   *int32
+	xStackId   *int64
 	count      *bool
 	orderby    *string
 	skip       *int32
@@ -900,7 +900,7 @@ type ApiProjectsListRequest struct {
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiProjectsListRequest) XStackId(xStackId int32) *ApiProjectsListRequest {
+func (r *ApiProjectsListRequest) XStackId(xStackId int64) *ApiProjectsListRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -1107,13 +1107,13 @@ func (a *ProjectsAPIService) ProjectsListExecute(r *ApiProjectsListRequest) (*Pr
 type ApiProjectsPartialUpdateRequest struct {
 	ctx                  context.Context
 	ApiService           *ProjectsAPIService
-	xStackId             *int32
+	xStackId             *int64
 	id                   int64
 	patchProjectApiModel *PatchProjectApiModel
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiProjectsPartialUpdateRequest) XStackId(xStackId int32) *ApiProjectsPartialUpdateRequest {
+func (r *ApiProjectsPartialUpdateRequest) XStackId(xStackId int64) *ApiProjectsPartialUpdateRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -1286,12 +1286,12 @@ func (a *ProjectsAPIService) ProjectsPartialUpdateExecute(r *ApiProjectsPartialU
 type ApiProjectsRetrieveRequest struct {
 	ctx        context.Context
 	ApiService *ProjectsAPIService
-	xStackId   *int32
+	xStackId   *int64
 	id         int64
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiProjectsRetrieveRequest) XStackId(xStackId int32) *ApiProjectsRetrieveRequest {
+func (r *ApiProjectsRetrieveRequest) XStackId(xStackId int64) *ApiProjectsRetrieveRequest {
 	r.xStackId = &xStackId
 	return r
 }

--- a/k6/api_schedules.go
+++ b/k6/api_schedules.go
@@ -26,13 +26,13 @@ type SchedulesAPIService service
 type ApiLoadTestsScheduleCreateRequest struct {
 	ctx                   context.Context
 	ApiService            *SchedulesAPIService
-	xStackId              *int32
+	xStackId              *int64
 	id                    int64
 	createScheduleRequest *CreateScheduleRequest
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiLoadTestsScheduleCreateRequest) XStackId(xStackId int32) *ApiLoadTestsScheduleCreateRequest {
+func (r *ApiLoadTestsScheduleCreateRequest) XStackId(xStackId int64) *ApiLoadTestsScheduleCreateRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -211,12 +211,12 @@ func (a *SchedulesAPIService) LoadTestsScheduleCreateExecute(r *ApiLoadTestsSche
 type ApiLoadTestsScheduleRetrieveRequest struct {
 	ctx        context.Context
 	ApiService *SchedulesAPIService
-	xStackId   *int32
+	xStackId   *int64
 	id         int64
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiLoadTestsScheduleRetrieveRequest) XStackId(xStackId int32) *ApiLoadTestsScheduleRetrieveRequest {
+func (r *ApiLoadTestsScheduleRetrieveRequest) XStackId(xStackId int64) *ApiLoadTestsScheduleRetrieveRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -369,12 +369,12 @@ func (a *SchedulesAPIService) LoadTestsScheduleRetrieveExecute(r *ApiLoadTestsSc
 type ApiScheduleActivateRequest struct {
 	ctx        context.Context
 	ApiService *SchedulesAPIService
-	xStackId   *int32
+	xStackId   *int64
 	id         int64
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiScheduleActivateRequest) XStackId(xStackId int32) *ApiScheduleActivateRequest {
+func (r *ApiScheduleActivateRequest) XStackId(xStackId int64) *ApiScheduleActivateRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -529,12 +529,12 @@ func (a *SchedulesAPIService) ScheduleActivateExecute(r *ApiScheduleActivateRequ
 type ApiScheduleDeactivateRequest struct {
 	ctx        context.Context
 	ApiService *SchedulesAPIService
-	xStackId   *int32
+	xStackId   *int64
 	id         int64
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiScheduleDeactivateRequest) XStackId(xStackId int32) *ApiScheduleDeactivateRequest {
+func (r *ApiScheduleDeactivateRequest) XStackId(xStackId int64) *ApiScheduleDeactivateRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -680,12 +680,12 @@ func (a *SchedulesAPIService) ScheduleDeactivateExecute(r *ApiScheduleDeactivate
 type ApiSchedulesDestroyRequest struct {
 	ctx        context.Context
 	ApiService *SchedulesAPIService
-	xStackId   *int32
+	xStackId   *int64
 	id         int64
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiSchedulesDestroyRequest) XStackId(xStackId int32) *ApiSchedulesDestroyRequest {
+func (r *ApiSchedulesDestroyRequest) XStackId(xStackId int64) *ApiSchedulesDestroyRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -826,14 +826,14 @@ func (a *SchedulesAPIService) SchedulesDestroyExecute(r *ApiSchedulesDestroyRequ
 type ApiSchedulesListRequest struct {
 	ctx        context.Context
 	ApiService *SchedulesAPIService
-	xStackId   *int32
+	xStackId   *int64
 	count      *bool
 	skip       *int32
 	top        *int32
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiSchedulesListRequest) XStackId(xStackId int32) *ApiSchedulesListRequest {
+func (r *ApiSchedulesListRequest) XStackId(xStackId int64) *ApiSchedulesListRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -1013,12 +1013,12 @@ func (a *SchedulesAPIService) SchedulesListExecute(r *ApiSchedulesListRequest) (
 type ApiSchedulesRetrieveRequest struct {
 	ctx        context.Context
 	ApiService *SchedulesAPIService
-	xStackId   *int32
+	xStackId   *int64
 	id         int64
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiSchedulesRetrieveRequest) XStackId(xStackId int32) *ApiSchedulesRetrieveRequest {
+func (r *ApiSchedulesRetrieveRequest) XStackId(xStackId int64) *ApiSchedulesRetrieveRequest {
 	r.xStackId = &xStackId
 	return r
 }

--- a/k6/api_test_runs.go
+++ b/k6/api_test_runs.go
@@ -27,7 +27,7 @@ type TestRunsAPIService service
 type ApiLoadTestsTestRunsRetrieveRequest struct {
 	ctx           context.Context
 	ApiService    *TestRunsAPIService
-	xStackId      *int32
+	xStackId      *int64
 	id            int64
 	count         *bool
 	orderby       *string
@@ -39,7 +39,7 @@ type ApiLoadTestsTestRunsRetrieveRequest struct {
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiLoadTestsTestRunsRetrieveRequest) XStackId(xStackId int32) *ApiLoadTestsTestRunsRetrieveRequest {
+func (r *ApiLoadTestsTestRunsRetrieveRequest) XStackId(xStackId int64) *ApiLoadTestsTestRunsRetrieveRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -269,12 +269,12 @@ func (a *TestRunsAPIService) LoadTestsTestRunsRetrieveExecute(r *ApiLoadTestsTes
 type ApiTestRunsAbortRequest struct {
 	ctx        context.Context
 	ApiService *TestRunsAPIService
-	xStackId   *int32
+	xStackId   *int64
 	id         int64
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiTestRunsAbortRequest) XStackId(xStackId int32) *ApiTestRunsAbortRequest {
+func (r *ApiTestRunsAbortRequest) XStackId(xStackId int64) *ApiTestRunsAbortRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -426,12 +426,12 @@ func (a *TestRunsAPIService) TestRunsAbortExecute(r *ApiTestRunsAbortRequest) (*
 type ApiTestRunsDestroyRequest struct {
 	ctx        context.Context
 	ApiService *TestRunsAPIService
-	xStackId   *int32
+	xStackId   *int64
 	id         int64
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiTestRunsDestroyRequest) XStackId(xStackId int32) *ApiTestRunsDestroyRequest {
+func (r *ApiTestRunsDestroyRequest) XStackId(xStackId int64) *ApiTestRunsDestroyRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -583,12 +583,12 @@ func (a *TestRunsAPIService) TestRunsDestroyExecute(r *ApiTestRunsDestroyRequest
 type ApiTestRunsDistributionRetrieveRequest struct {
 	ctx        context.Context
 	ApiService *TestRunsAPIService
-	xStackId   *int32
+	xStackId   *int64
 	id         int64
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiTestRunsDistributionRetrieveRequest) XStackId(xStackId int32) *ApiTestRunsDistributionRetrieveRequest {
+func (r *ApiTestRunsDistributionRetrieveRequest) XStackId(xStackId int64) *ApiTestRunsDistributionRetrieveRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -741,7 +741,7 @@ func (a *TestRunsAPIService) TestRunsDistributionRetrieveExecute(r *ApiTestRunsD
 type ApiTestRunsListRequest struct {
 	ctx           context.Context
 	ApiService    *TestRunsAPIService
-	xStackId      *int32
+	xStackId      *int64
 	count         *bool
 	skip          *int32
 	top           *int32
@@ -750,7 +750,7 @@ type ApiTestRunsListRequest struct {
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiTestRunsListRequest) XStackId(xStackId int32) *ApiTestRunsListRequest {
+func (r *ApiTestRunsListRequest) XStackId(xStackId int64) *ApiTestRunsListRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -948,13 +948,13 @@ func (a *TestRunsAPIService) TestRunsListExecute(r *ApiTestRunsListRequest) (*Te
 type ApiTestRunsPartialUpdateRequest struct {
 	ctx                  context.Context
 	ApiService           *TestRunsAPIService
-	xStackId             *int32
+	xStackId             *int64
 	id                   int64
 	patchTestRunApiModel *PatchTestRunApiModel
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiTestRunsPartialUpdateRequest) XStackId(xStackId int32) *ApiTestRunsPartialUpdateRequest {
+func (r *ApiTestRunsPartialUpdateRequest) XStackId(xStackId int64) *ApiTestRunsPartialUpdateRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -1116,12 +1116,12 @@ func (a *TestRunsAPIService) TestRunsPartialUpdateExecute(r *ApiTestRunsPartialU
 type ApiTestRunsRetrieveRequest struct {
 	ctx        context.Context
 	ApiService *TestRunsAPIService
-	xStackId   *int32
+	xStackId   *int64
 	id         int64
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiTestRunsRetrieveRequest) XStackId(xStackId int32) *ApiTestRunsRetrieveRequest {
+func (r *ApiTestRunsRetrieveRequest) XStackId(xStackId int64) *ApiTestRunsRetrieveRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -1274,12 +1274,12 @@ func (a *TestRunsAPIService) TestRunsRetrieveExecute(r *ApiTestRunsRetrieveReque
 type ApiTestRunsSaveRequest struct {
 	ctx        context.Context
 	ApiService *TestRunsAPIService
-	xStackId   *int32
+	xStackId   *int64
 	id         int64
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiTestRunsSaveRequest) XStackId(xStackId int32) *ApiTestRunsSaveRequest {
+func (r *ApiTestRunsSaveRequest) XStackId(xStackId int64) *ApiTestRunsSaveRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -1434,12 +1434,12 @@ func (a *TestRunsAPIService) TestRunsSaveExecute(r *ApiTestRunsSaveRequest) (*ht
 type ApiTestRunsScriptRetrieveRequest struct {
 	ctx        context.Context
 	ApiService *TestRunsAPIService
-	xStackId   *int32
+	xStackId   *int64
 	id         int64
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiTestRunsScriptRetrieveRequest) XStackId(xStackId int32) *ApiTestRunsScriptRetrieveRequest {
+func (r *ApiTestRunsScriptRetrieveRequest) XStackId(xStackId int64) *ApiTestRunsScriptRetrieveRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -1592,12 +1592,12 @@ func (a *TestRunsAPIService) TestRunsScriptRetrieveExecute(r *ApiTestRunsScriptR
 type ApiTestRunsStarRequest struct {
 	ctx        context.Context
 	ApiService *TestRunsAPIService
-	xStackId   *int32
+	xStackId   *int64
 	id         int64
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiTestRunsStarRequest) XStackId(xStackId int32) *ApiTestRunsStarRequest {
+func (r *ApiTestRunsStarRequest) XStackId(xStackId int64) *ApiTestRunsStarRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -1738,12 +1738,12 @@ func (a *TestRunsAPIService) TestRunsStarExecute(r *ApiTestRunsStarRequest) (*ht
 type ApiTestRunsUnsaveRequest struct {
 	ctx        context.Context
 	ApiService *TestRunsAPIService
-	xStackId   *int32
+	xStackId   *int64
 	id         int64
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiTestRunsUnsaveRequest) XStackId(xStackId int32) *ApiTestRunsUnsaveRequest {
+func (r *ApiTestRunsUnsaveRequest) XStackId(xStackId int64) *ApiTestRunsUnsaveRequest {
 	r.xStackId = &xStackId
 	return r
 }
@@ -1887,12 +1887,12 @@ func (a *TestRunsAPIService) TestRunsUnsaveExecute(r *ApiTestRunsUnsaveRequest) 
 type ApiTestRunsUnstarRequest struct {
 	ctx        context.Context
 	ApiService *TestRunsAPIService
-	xStackId   *int32
+	xStackId   *int64
 	id         int64
 }
 
 // Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-func (r *ApiTestRunsUnstarRequest) XStackId(xStackId int32) *ApiTestRunsUnstarRequest {
+func (r *ApiTestRunsUnstarRequest) XStackId(xStackId int64) *ApiTestRunsUnstarRequest {
 	r.xStackId = &xStackId
 	return r
 }

--- a/k6/docs/LabelsAPI.md
+++ b/k6/docs/LabelsAPI.md
@@ -35,8 +35,8 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-	labelKeyCreateRequest := *openapiclient.NewLabelKeyCreateRequest([]openapiclient.LabelKeyCreateItem{*openapiclient.NewLabelKeyCreateItem("Key_example")}) // LabelKeyCreateRequest | 
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	labelKeyCreateRequest := *openapiclient.NewLabelKeyCreateRequest([]openapiclient.LabelKeyCreateItem{*openapiclient.NewLabelKeyCreateItem("Key_example")}) // LabelKeyCreateRequest |
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)
@@ -61,8 +61,8 @@ Other parameters are passed through a pointer to a apiLabelsCreateRequest struct
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
- **labelKeyCreateRequest** | [**LabelKeyCreateRequest**](LabelKeyCreateRequest.md) |  | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
+ **labelKeyCreateRequest** | [**LabelKeyCreateRequest**](LabelKeyCreateRequest.md) |  |
 
 ### Return type
 
@@ -103,7 +103,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	id := int64(789) // int64 | ID of the label key.
 
 	configuration := openapiclient.NewConfiguration()
@@ -122,7 +122,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**id** | **int64** | ID of the label key. | 
+**id** | **int64** | ID of the label key. |
 
 ### Other Parameters
 
@@ -131,7 +131,7 @@ Other parameters are passed through a pointer to a apiLabelsDestroyRequest struc
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
 
 ### Return type
@@ -173,7 +173,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)
@@ -198,7 +198,7 @@ Other parameters are passed through a pointer to a apiLabelsListRequest struct v
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
 ### Return type
 
@@ -239,7 +239,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	id := int64(789) // int64 | ID of the label key.
 	labelKeyPatchRequest := *openapiclient.NewLabelKeyPatchRequest() // LabelKeyPatchRequest |  (optional)
 
@@ -261,7 +261,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**id** | **int64** | ID of the label key. | 
+**id** | **int64** | ID of the label key. |
 
 ### Other Parameters
 
@@ -270,9 +270,9 @@ Other parameters are passed through a pointer to a apiLabelsPartialUpdateRequest
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
- **labelKeyPatchRequest** | [**LabelKeyPatchRequest**](LabelKeyPatchRequest.md) |  | 
+ **labelKeyPatchRequest** | [**LabelKeyPatchRequest**](LabelKeyPatchRequest.md) |  |
 
 ### Return type
 
@@ -313,7 +313,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	key := "key_example" // string | Label key name.
 	projectId := int64(789) // int64 | ID of the project.
 
@@ -333,8 +333,8 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**key** | **string** | Label key name. | 
-**projectId** | **int64** | ID of the project. | 
+**key** | **string** | Label key name. |
+**projectId** | **int64** | ID of the project. |
 
 ### Other Parameters
 
@@ -343,7 +343,7 @@ Other parameters are passed through a pointer to a apiProjectsLabelsDestroyReque
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
 
 
@@ -386,7 +386,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	projectId := int64(789) // int64 | ID of the project.
 
 	configuration := openapiclient.NewConfiguration()
@@ -407,7 +407,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**projectId** | **int64** | ID of the project. | 
+**projectId** | **int64** | ID of the project. |
 
 ### Other Parameters
 
@@ -416,7 +416,7 @@ Other parameters are passed through a pointer to a apiProjectsLabelsListRequest 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
 
 ### Return type
@@ -458,9 +458,9 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	projectId := int64(789) // int64 | ID of the project.
-	projectLabelPutRequest := *openapiclient.NewProjectLabelPutRequest([]openapiclient.ProjectLabelPutItem{*openapiclient.NewProjectLabelPutItem("Value_example")}) // ProjectLabelPutRequest | 
+	projectLabelPutRequest := *openapiclient.NewProjectLabelPutRequest([]openapiclient.ProjectLabelPutItem{*openapiclient.NewProjectLabelPutItem("Value_example")}) // ProjectLabelPutRequest |
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)
@@ -480,7 +480,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**projectId** | **int64** | ID of the project. | 
+**projectId** | **int64** | ID of the project. |
 
 ### Other Parameters
 
@@ -489,9 +489,9 @@ Other parameters are passed through a pointer to a apiProjectsLabelsUpdateReques
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
- **projectLabelPutRequest** | [**ProjectLabelPutRequest**](ProjectLabelPutRequest.md) |  | 
+ **projectLabelPutRequest** | [**ProjectLabelPutRequest**](ProjectLabelPutRequest.md) |  |
 
 ### Return type
 

--- a/k6/docs/LoadTestsAPI.md
+++ b/k6/docs/LoadTestsAPI.md
@@ -39,7 +39,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	id := int64(789) // int64 | ID of the load test.
 
 	configuration := openapiclient.NewConfiguration()
@@ -58,7 +58,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**id** | **int64** | ID of the load test. | 
+**id** | **int64** | ID of the load test. |
 
 ### Other Parameters
 
@@ -67,7 +67,7 @@ Other parameters are passed through a pointer to a apiLoadTestsDestroyRequest st
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
 
 ### Return type
@@ -109,7 +109,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	count := true // bool | Include collection length in the response object as `@count`. (optional)
 	orderby := "id desc,project_id" // string | Comma-separated list of fields to use when ordering the results. Available fields: - id - project_id - name - created - updated  The default ascending order can be reversed by appending the `desc` specifier. (optional)
 	skip := int32(56) // int32 | The initial index from which to return the results. (optional)
@@ -139,12 +139,12 @@ Other parameters are passed through a pointer to a apiLoadTestsListRequest struc
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
- **count** | **bool** | Include collection length in the response object as &#x60;@count&#x60;. | 
- **orderby** | **string** | Comma-separated list of fields to use when ordering the results. Available fields: - id - project_id - name - created - updated  The default ascending order can be reversed by appending the &#x60;desc&#x60; specifier. | 
- **skip** | **int32** | The initial index from which to return the results. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
+ **count** | **bool** | Include collection length in the response object as &#x60;@count&#x60;. |
+ **orderby** | **string** | Comma-separated list of fields to use when ordering the results. Available fields: - id - project_id - name - created - updated  The default ascending order can be reversed by appending the &#x60;desc&#x60; specifier. |
+ **skip** | **int32** | The initial index from which to return the results. |
  **top** | **int32** | Number of results to return per page. | [default to 1000]
- **name** | **string** | Filter results by load test name (exact match). | 
+ **name** | **string** | Filter results by load test name (exact match). |
 
 ### Return type
 
@@ -185,9 +185,9 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	id := int64(789) // int64 | ID of the load test.
-	moveLoadTestApiModel := *openapiclient.NewMoveLoadTestApiModel(int64(123)) // MoveLoadTestApiModel | 
+	moveLoadTestApiModel := *openapiclient.NewMoveLoadTestApiModel(int64(123)) // MoveLoadTestApiModel |
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)
@@ -205,7 +205,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**id** | **int64** | ID of the load test. | 
+**id** | **int64** | ID of the load test. |
 
 ### Other Parameters
 
@@ -214,9 +214,9 @@ Other parameters are passed through a pointer to a apiLoadTestsMoveRequest struc
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
- **moveLoadTestApiModel** | [**MoveLoadTestApiModel**](MoveLoadTestApiModel.md) |  | 
+ **moveLoadTestApiModel** | [**MoveLoadTestApiModel**](MoveLoadTestApiModel.md) |  |
 
 ### Return type
 
@@ -257,7 +257,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	id := int64(789) // int64 | ID of the load test.
 	patchLoadTestApiModel := *openapiclient.NewPatchLoadTestApiModel() // PatchLoadTestApiModel |  (optional)
 
@@ -277,7 +277,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**id** | **int64** | ID of the load test. | 
+**id** | **int64** | ID of the load test. |
 
 ### Other Parameters
 
@@ -286,9 +286,9 @@ Other parameters are passed through a pointer to a apiLoadTestsPartialUpdateRequ
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
- **patchLoadTestApiModel** | [**PatchLoadTestApiModel**](PatchLoadTestApiModel.md) |  | 
+ **patchLoadTestApiModel** | [**PatchLoadTestApiModel**](PatchLoadTestApiModel.md) |  |
 
 ### Return type
 
@@ -329,7 +329,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	id := int64(789) // int64 | ID of the load test.
 
 	configuration := openapiclient.NewConfiguration()
@@ -350,7 +350,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**id** | **int64** | ID of the load test. | 
+**id** | **int64** | ID of the load test. |
 
 ### Other Parameters
 
@@ -359,7 +359,7 @@ Other parameters are passed through a pointer to a apiLoadTestsRetrieveRequest s
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
 
 ### Return type
@@ -401,7 +401,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	id := int64(789) // int64 | ID of the load test.
 
 	configuration := openapiclient.NewConfiguration()
@@ -422,7 +422,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**id** | **int64** | ID of the load test. | 
+**id** | **int64** | ID of the load test. |
 
 ### Other Parameters
 
@@ -431,7 +431,7 @@ Other parameters are passed through a pointer to a apiLoadTestsScriptRetrieveReq
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
 
 ### Return type
@@ -473,7 +473,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	id := int64(789) // int64 | ID of the load test.
 	body := os.NewFile(1234, "some_file") // *os.File |  (optional)
 
@@ -493,7 +493,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**id** | **int64** | ID of the load test. | 
+**id** | **int64** | ID of the load test. |
 
 ### Other Parameters
 
@@ -502,9 +502,9 @@ Other parameters are passed through a pointer to a apiLoadTestsScriptUpdateReque
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
- **body** | ***os.File** |  | 
+ **body** | ***os.File** |  |
 
 ### Return type
 
@@ -545,7 +545,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	id := int64(789) // int64 | ID of the load test.
 	k6IdempotencyKey := "k6IdempotencyKey_example" // string | Idempotency key to prevent duplicate test starts when retrying requests. The key is valid for 10 minutes. (optional)
 
@@ -567,7 +567,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**id** | **int64** | ID of the load test. | 
+**id** | **int64** | ID of the load test. |
 
 ### Other Parameters
 
@@ -576,9 +576,9 @@ Other parameters are passed through a pointer to a apiLoadTestsStartRequest stru
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
- **k6IdempotencyKey** | **string** | Idempotency key to prevent duplicate test starts when retrying requests. The key is valid for 10 minutes. | 
+ **k6IdempotencyKey** | **string** | Idempotency key to prevent duplicate test starts when retrying requests. The key is valid for 10 minutes. |
 
 ### Return type
 
@@ -619,7 +619,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	id := int64(789) // int64 | ID of the project.
 	name := "name_example" // string | Unique name of the test within the project.
 	script := os.NewFile(1234, "some_file") // *os.File | Test script in the form of a UTF-8 encoded text or a k6 .tar archive. (optional)
@@ -643,7 +643,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**id** | **int64** | ID of the project. | 
+**id** | **int64** | ID of the project. |
 
 ### Other Parameters
 
@@ -652,11 +652,11 @@ Other parameters are passed through a pointer to a apiProjectsLoadTestsCreateReq
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
- **name** | **string** | Unique name of the test within the project. | 
- **script** | ***os.File** | Test script in the form of a UTF-8 encoded text or a k6 .tar archive. | 
- **k6Version** | **int32** | Identifier of the k6 version used to run the test. | 
+ **name** | **string** | Unique name of the test within the project. |
+ **script** | ***os.File** | Test script in the form of a UTF-8 encoded text or a k6 .tar archive. |
+ **k6Version** | **int32** | Identifier of the k6 version used to run the test. |
 
 ### Return type
 
@@ -697,7 +697,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	id := int64(789) // int64 | ID of the project.
 	count := true // bool | Include collection length in the response object as `@count`. (optional)
 	orderby := "id desc,project_id" // string | Comma-separated list of fields to use when ordering the results. Available fields: - id - project_id - name - created - updated  The default ascending order can be reversed by appending the `desc` specifier. (optional)
@@ -723,7 +723,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**id** | **int64** | ID of the project. | 
+**id** | **int64** | ID of the project. |
 
 ### Other Parameters
 
@@ -732,13 +732,13 @@ Other parameters are passed through a pointer to a apiProjectsLoadTestsRetrieveR
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
- **count** | **bool** | Include collection length in the response object as &#x60;@count&#x60;. | 
- **orderby** | **string** | Comma-separated list of fields to use when ordering the results. Available fields: - id - project_id - name - created - updated  The default ascending order can be reversed by appending the &#x60;desc&#x60; specifier. | 
- **skip** | **int32** | The initial index from which to return the results. | 
+ **count** | **bool** | Include collection length in the response object as &#x60;@count&#x60;. |
+ **orderby** | **string** | Comma-separated list of fields to use when ordering the results. Available fields: - id - project_id - name - created - updated  The default ascending order can be reversed by appending the &#x60;desc&#x60; specifier. |
+ **skip** | **int32** | The initial index from which to return the results. |
  **top** | **int32** | Number of results to return per page. | [default to 1000]
- **name** | **string** | Filter results by load test name (exact match). | 
+ **name** | **string** | Filter results by load test name (exact match). |
 
 ### Return type
 
@@ -779,8 +779,8 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-	validateOptionsRequest := *openapiclient.NewValidateOptionsRequest(*openapiclient.NewOptions()) // ValidateOptionsRequest | 
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	validateOptionsRequest := *openapiclient.NewValidateOptionsRequest(*openapiclient.NewOptions()) // ValidateOptionsRequest |
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)
@@ -805,8 +805,8 @@ Other parameters are passed through a pointer to a apiValidateOptionsRequest str
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
- **validateOptionsRequest** | [**ValidateOptionsRequest**](ValidateOptionsRequest.md) |  | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
+ **validateOptionsRequest** | [**ValidateOptionsRequest**](ValidateOptionsRequest.md) |  |
 
 ### Return type
 

--- a/k6/docs/LoadZonesAPI.md
+++ b/k6/docs/LoadZonesAPI.md
@@ -33,7 +33,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	id := int64(789) // int64 | ID of the load zone.
 
 	configuration := openapiclient.NewConfiguration()
@@ -54,7 +54,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**id** | **int64** | ID of the load zone. | 
+**id** | **int64** | ID of the load zone. |
 
 ### Other Parameters
 
@@ -63,7 +63,7 @@ Other parameters are passed through a pointer to a apiLoadZonesAllowedProjectsRe
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
 
 ### Return type
@@ -105,9 +105,9 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	id := int64(789) // int64 | ID of the load zone.
-	updateAllowedProjectsListApiModel := *openapiclient.NewUpdateAllowedProjectsListApiModel([]openapiclient.AllowedProjectToUpdateApiModel{*openapiclient.NewAllowedProjectToUpdateApiModel(int64(123))}) // UpdateAllowedProjectsListApiModel | 
+	updateAllowedProjectsListApiModel := *openapiclient.NewUpdateAllowedProjectsListApiModel([]openapiclient.AllowedProjectToUpdateApiModel{*openapiclient.NewAllowedProjectToUpdateApiModel(int64(123))}) // UpdateAllowedProjectsListApiModel |
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)
@@ -127,7 +127,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**id** | **int64** | ID of the load zone. | 
+**id** | **int64** | ID of the load zone. |
 
 ### Other Parameters
 
@@ -136,9 +136,9 @@ Other parameters are passed through a pointer to a apiLoadZonesAllowedProjectsUp
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
- **updateAllowedProjectsListApiModel** | [**UpdateAllowedProjectsListApiModel**](UpdateAllowedProjectsListApiModel.md) |  | 
+ **updateAllowedProjectsListApiModel** | [**UpdateAllowedProjectsListApiModel**](UpdateAllowedProjectsListApiModel.md) |  |
 
 ### Return type
 
@@ -179,7 +179,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	k6LoadZoneId := "k6LoadZoneId_example" // string | Filter results by k6 load zone ID (exact match). (optional)
 
 	configuration := openapiclient.NewConfiguration()
@@ -205,8 +205,8 @@ Other parameters are passed through a pointer to a apiLoadZonesListRequest struc
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
- **k6LoadZoneId** | **string** | Filter results by k6 load zone ID (exact match). | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
+ **k6LoadZoneId** | **string** | Filter results by k6 load zone ID (exact match). |
 
 ### Return type
 
@@ -247,7 +247,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	id := int64(789) // int64 | ID of the project.
 
 	configuration := openapiclient.NewConfiguration()
@@ -268,7 +268,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**id** | **int64** | ID of the project. | 
+**id** | **int64** | ID of the project. |
 
 ### Other Parameters
 
@@ -277,7 +277,7 @@ Other parameters are passed through a pointer to a apiProjectsAllowedLoadZonesRe
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
 
 ### Return type
@@ -319,9 +319,9 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	id := int64(789) // int64 | ID of the project.
-	updateAllowedLoadZonesListApiModel := *openapiclient.NewUpdateAllowedLoadZonesListApiModel([]openapiclient.AllowedLoadZoneToUpdateApiModel{*openapiclient.NewAllowedLoadZoneToUpdateApiModel(int64(123))}) // UpdateAllowedLoadZonesListApiModel | 
+	updateAllowedLoadZonesListApiModel := *openapiclient.NewUpdateAllowedLoadZonesListApiModel([]openapiclient.AllowedLoadZoneToUpdateApiModel{*openapiclient.NewAllowedLoadZoneToUpdateApiModel(int64(123))}) // UpdateAllowedLoadZonesListApiModel |
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)
@@ -341,7 +341,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**id** | **int64** | ID of the project. | 
+**id** | **int64** | ID of the project. |
 
 ### Other Parameters
 
@@ -350,9 +350,9 @@ Other parameters are passed through a pointer to a apiProjectsAllowedLoadZonesUp
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
- **updateAllowedLoadZonesListApiModel** | [**UpdateAllowedLoadZonesListApiModel**](UpdateAllowedLoadZonesListApiModel.md) |  | 
+ **updateAllowedLoadZonesListApiModel** | [**UpdateAllowedLoadZonesListApiModel**](UpdateAllowedLoadZonesListApiModel.md) |  |
 
 ### Return type
 

--- a/k6/docs/ProjectsAPI.md
+++ b/k6/docs/ProjectsAPI.md
@@ -36,7 +36,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	count := true // bool | Include collection length in the response object as `@count`. (optional)
 	skip := int32(56) // int32 | The initial index from which to return the results. (optional)
 	top := int32(56) // int32 | Number of results to return per page. (optional) (default to 1000)
@@ -65,11 +65,11 @@ Other parameters are passed through a pointer to a apiProjectLimitsRetrieveReque
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
- **count** | **bool** | Include collection length in the response object as &#x60;@count&#x60;. | 
- **skip** | **int32** | The initial index from which to return the results. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
+ **count** | **bool** | Include collection length in the response object as &#x60;@count&#x60;. |
+ **skip** | **int32** | The initial index from which to return the results. |
  **top** | **int32** | Number of results to return per page. | [default to 1000]
- **projectIdIn** | **[]int32** | Filter results by project ID (comma-separated list of IDs). | 
+ **projectIdIn** | **[]int32** | Filter results by project ID (comma-separated list of IDs). |
 
 ### Return type
 
@@ -110,8 +110,8 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
-	createProjectApiModel := *openapiclient.NewCreateProjectApiModel("Name_example") // CreateProjectApiModel | 
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	createProjectApiModel := *openapiclient.NewCreateProjectApiModel("Name_example") // CreateProjectApiModel |
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)
@@ -136,8 +136,8 @@ Other parameters are passed through a pointer to a apiProjectsCreateRequest stru
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
- **createProjectApiModel** | [**CreateProjectApiModel**](CreateProjectApiModel.md) |  | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
+ **createProjectApiModel** | [**CreateProjectApiModel**](CreateProjectApiModel.md) |  |
 
 ### Return type
 
@@ -178,7 +178,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	id := int64(789) // int64 | ID of the project.
 
 	configuration := openapiclient.NewConfiguration()
@@ -197,7 +197,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**id** | **int64** | ID of the project. | 
+**id** | **int64** | ID of the project. |
 
 ### Other Parameters
 
@@ -206,7 +206,7 @@ Other parameters are passed through a pointer to a apiProjectsDestroyRequest str
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
 
 ### Return type
@@ -248,7 +248,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	id := int64(789) // int64 | ID of the project.
 	patchProjectLimitsRequest := *openapiclient.NewPatchProjectLimitsRequest() // PatchProjectLimitsRequest |  (optional)
 
@@ -268,7 +268,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**id** | **int64** | ID of the project. | 
+**id** | **int64** | ID of the project. |
 
 ### Other Parameters
 
@@ -277,9 +277,9 @@ Other parameters are passed through a pointer to a apiProjectsLimitsPartialUpdat
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
- **patchProjectLimitsRequest** | [**PatchProjectLimitsRequest**](PatchProjectLimitsRequest.md) |  | 
+ **patchProjectLimitsRequest** | [**PatchProjectLimitsRequest**](PatchProjectLimitsRequest.md) |  |
 
 ### Return type
 
@@ -320,7 +320,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	id := int64(789) // int64 | ID of the project.
 
 	configuration := openapiclient.NewConfiguration()
@@ -341,7 +341,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**id** | **int64** | ID of the project. | 
+**id** | **int64** | ID of the project. |
 
 ### Other Parameters
 
@@ -350,7 +350,7 @@ Other parameters are passed through a pointer to a apiProjectsLimitsRetrieveRequ
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
 
 ### Return type
@@ -392,7 +392,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	count := true // bool | Include collection length in the response object as `@count`. (optional)
 	orderby := "created desc,name" // string | Comma-separated list of fields to use when ordering the results. Available fields: - created - name  The default ascending order can be reversed by appending the `desc` specifier. (optional)
 	skip := int32(56) // int32 | The initial index from which to return the results. (optional)
@@ -423,13 +423,13 @@ Other parameters are passed through a pointer to a apiProjectsListRequest struct
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
- **count** | **bool** | Include collection length in the response object as &#x60;@count&#x60;. | 
- **orderby** | **string** | Comma-separated list of fields to use when ordering the results. Available fields: - created - name  The default ascending order can be reversed by appending the &#x60;desc&#x60; specifier. | 
- **skip** | **int32** | The initial index from which to return the results. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
+ **count** | **bool** | Include collection length in the response object as &#x60;@count&#x60;. |
+ **orderby** | **string** | Comma-separated list of fields to use when ordering the results. Available fields: - created - name  The default ascending order can be reversed by appending the &#x60;desc&#x60; specifier. |
+ **skip** | **int32** | The initial index from which to return the results. |
  **top** | **int32** | Number of results to return per page. | [default to 1000]
- **name** | **string** | Filter results by project name (exact match). | 
- **nameSearch** | **string** | Search projects by name. | 
+ **name** | **string** | Filter results by project name (exact match). |
+ **nameSearch** | **string** | Search projects by name. |
 
 ### Return type
 
@@ -470,9 +470,9 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	id := int64(789) // int64 | ID of the project.
-	patchProjectApiModel := *openapiclient.NewPatchProjectApiModel("Name_example") // PatchProjectApiModel | 
+	patchProjectApiModel := *openapiclient.NewPatchProjectApiModel("Name_example") // PatchProjectApiModel |
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)
@@ -490,7 +490,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**id** | **int64** | ID of the project. | 
+**id** | **int64** | ID of the project. |
 
 ### Other Parameters
 
@@ -499,9 +499,9 @@ Other parameters are passed through a pointer to a apiProjectsPartialUpdateReque
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
- **patchProjectApiModel** | [**PatchProjectApiModel**](PatchProjectApiModel.md) |  | 
+ **patchProjectApiModel** | [**PatchProjectApiModel**](PatchProjectApiModel.md) |  |
 
 ### Return type
 
@@ -542,7 +542,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	id := int64(789) // int64 | ID of the project.
 
 	configuration := openapiclient.NewConfiguration()
@@ -563,7 +563,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**id** | **int64** | ID of the project. | 
+**id** | **int64** | ID of the project. |
 
 ### Other Parameters
 
@@ -572,7 +572,7 @@ Other parameters are passed through a pointer to a apiProjectsRetrieveRequest st
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
 
 ### Return type

--- a/k6/docs/SchedulesAPI.md
+++ b/k6/docs/SchedulesAPI.md
@@ -36,9 +36,9 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	id := int64(789) // int64 | ID of the load test.
-	createScheduleRequest := *openapiclient.NewCreateScheduleRequest(time.Now()) // CreateScheduleRequest | 
+	createScheduleRequest := *openapiclient.NewCreateScheduleRequest(time.Now()) // CreateScheduleRequest |
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)
@@ -58,7 +58,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**id** | **int64** | ID of the load test. | 
+**id** | **int64** | ID of the load test. |
 
 ### Other Parameters
 
@@ -67,9 +67,9 @@ Other parameters are passed through a pointer to a apiLoadTestsScheduleCreateReq
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
- **createScheduleRequest** | [**CreateScheduleRequest**](CreateScheduleRequest.md) |  | 
+ **createScheduleRequest** | [**CreateScheduleRequest**](CreateScheduleRequest.md) |  |
 
 ### Return type
 
@@ -110,7 +110,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	id := int64(789) // int64 | ID of the load test.
 
 	configuration := openapiclient.NewConfiguration()
@@ -131,7 +131,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**id** | **int64** | ID of the load test. | 
+**id** | **int64** | ID of the load test. |
 
 ### Other Parameters
 
@@ -140,7 +140,7 @@ Other parameters are passed through a pointer to a apiLoadTestsScheduleRetrieveR
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
 
 ### Return type
@@ -182,7 +182,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	id := int64(789) // int64 | ID of the schedule.
 
 	configuration := openapiclient.NewConfiguration()
@@ -201,7 +201,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**id** | **int64** | ID of the schedule. | 
+**id** | **int64** | ID of the schedule. |
 
 ### Other Parameters
 
@@ -210,7 +210,7 @@ Other parameters are passed through a pointer to a apiScheduleActivateRequest st
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
 
 ### Return type
@@ -252,7 +252,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	id := int64(789) // int64 | ID of the schedule.
 
 	configuration := openapiclient.NewConfiguration()
@@ -271,7 +271,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**id** | **int64** | ID of the schedule. | 
+**id** | **int64** | ID of the schedule. |
 
 ### Other Parameters
 
@@ -280,7 +280,7 @@ Other parameters are passed through a pointer to a apiScheduleDeactivateRequest 
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
 
 ### Return type
@@ -322,7 +322,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	id := int64(789) // int64 | ID of the schedule.
 
 	configuration := openapiclient.NewConfiguration()
@@ -341,7 +341,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**id** | **int64** | ID of the schedule. | 
+**id** | **int64** | ID of the schedule. |
 
 ### Other Parameters
 
@@ -350,7 +350,7 @@ Other parameters are passed through a pointer to a apiSchedulesDestroyRequest st
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
 
 ### Return type
@@ -392,7 +392,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	count := true // bool | Include collection length in the response object as `@count`. (optional)
 	skip := int32(56) // int32 | The initial index from which to return the results. (optional)
 	top := int32(56) // int32 | Number of results to return per page. (optional) (default to 1000)
@@ -420,9 +420,9 @@ Other parameters are passed through a pointer to a apiSchedulesListRequest struc
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
- **count** | **bool** | Include collection length in the response object as &#x60;@count&#x60;. | 
- **skip** | **int32** | The initial index from which to return the results. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
+ **count** | **bool** | Include collection length in the response object as &#x60;@count&#x60;. |
+ **skip** | **int32** | The initial index from which to return the results. |
  **top** | **int32** | Number of results to return per page. | [default to 1000]
 
 ### Return type
@@ -464,7 +464,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	id := int64(789) // int64 | ID of the schedule.
 
 	configuration := openapiclient.NewConfiguration()
@@ -485,7 +485,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**id** | **int64** | ID of the schedule. | 
+**id** | **int64** | ID of the schedule. |
 
 ### Other Parameters
 
@@ -494,7 +494,7 @@ Other parameters are passed through a pointer to a apiSchedulesRetrieveRequest s
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
 
 ### Return type

--- a/k6/docs/TestRunsAPI.md
+++ b/k6/docs/TestRunsAPI.md
@@ -41,7 +41,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	id := int64(789) // int64 | ID of the load test.
 	count := true // bool | Include collection length in the response object as `@count`. (optional)
 	orderby := "created desc" // string | Comma-separated list of fields to use when ordering the results. Available fields: - created  The default ascending order can be reversed by appending the `desc` specifier. (optional)
@@ -69,7 +69,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**id** | **int64** | ID of the load test. | 
+**id** | **int64** | ID of the load test. |
 
 ### Other Parameters
 
@@ -78,15 +78,15 @@ Other parameters are passed through a pointer to a apiLoadTestsTestRunsRetrieveR
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
- **count** | **bool** | Include collection length in the response object as &#x60;@count&#x60;. | 
- **orderby** | **string** | Comma-separated list of fields to use when ordering the results. Available fields: - created  The default ascending order can be reversed by appending the &#x60;desc&#x60; specifier. | 
- **skip** | **int32** | The initial index from which to return the results. | 
+ **count** | **bool** | Include collection length in the response object as &#x60;@count&#x60;. |
+ **orderby** | **string** | Comma-separated list of fields to use when ordering the results. Available fields: - created  The default ascending order can be reversed by appending the &#x60;desc&#x60; specifier. |
+ **skip** | **int32** | The initial index from which to return the results. |
  **top** | **int32** | Number of results to return per page. | [default to 1000]
- **createdAfter** | **time.Time** | Filter test runs created on or after this date and time (inclusive). | 
- **createdBefore** | **time.Time** | Filter test runs created before this date and time (non-inclusive). | 
- **isStarred** | **bool** | Filter by starred state. &#x60;true&#x60; or &#x60;1&#x60; returns only starred runs; &#x60;false&#x60; or &#x60;0&#x60; returns only unstarred runs. Omit the parameter to return all runs for this load test. | 
+ **createdAfter** | **time.Time** | Filter test runs created on or after this date and time (inclusive). |
+ **createdBefore** | **time.Time** | Filter test runs created before this date and time (non-inclusive). |
+ **isStarred** | **bool** | Filter by starred state. &#x60;true&#x60; or &#x60;1&#x60; returns only starred runs; &#x60;false&#x60; or &#x60;0&#x60; returns only unstarred runs. Omit the parameter to return all runs for this load test. |
 
 ### Return type
 
@@ -127,7 +127,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	id := int64(789) // int64 | ID of the load test run.
 
 	configuration := openapiclient.NewConfiguration()
@@ -146,7 +146,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**id** | **int64** | ID of the load test run. | 
+**id** | **int64** | ID of the load test run. |
 
 ### Other Parameters
 
@@ -155,7 +155,7 @@ Other parameters are passed through a pointer to a apiTestRunsAbortRequest struc
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
 
 ### Return type
@@ -197,7 +197,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	id := int64(789) // int64 | ID of the load test run.
 
 	configuration := openapiclient.NewConfiguration()
@@ -216,7 +216,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**id** | **int64** | ID of the load test run. | 
+**id** | **int64** | ID of the load test run. |
 
 ### Other Parameters
 
@@ -225,7 +225,7 @@ Other parameters are passed through a pointer to a apiTestRunsDestroyRequest str
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
 
 ### Return type
@@ -267,7 +267,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	id := int64(789) // int64 | ID of the load test run.
 
 	configuration := openapiclient.NewConfiguration()
@@ -288,7 +288,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**id** | **int64** | ID of the load test run. | 
+**id** | **int64** | ID of the load test run. |
 
 ### Other Parameters
 
@@ -297,7 +297,7 @@ Other parameters are passed through a pointer to a apiTestRunsDistributionRetrie
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
 
 ### Return type
@@ -340,7 +340,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	count := true // bool | Include collection length in the response object as `@count`. (optional)
 	skip := int32(56) // int32 | The initial index from which to return the results. (optional)
 	top := int32(56) // int32 | Number of results to return per page. (optional) (default to 1000)
@@ -370,12 +370,12 @@ Other parameters are passed through a pointer to a apiTestRunsListRequest struct
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
- **count** | **bool** | Include collection length in the response object as &#x60;@count&#x60;. | 
- **skip** | **int32** | The initial index from which to return the results. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
+ **count** | **bool** | Include collection length in the response object as &#x60;@count&#x60;. |
+ **skip** | **int32** | The initial index from which to return the results. |
  **top** | **int32** | Number of results to return per page. | [default to 1000]
- **createdAfter** | **time.Time** | Filter test runs created on or after this date and time (inclusive). | 
- **createdBefore** | **time.Time** | Filter test runs created before this date and time (non-inclusive). | 
+ **createdAfter** | **time.Time** | Filter test runs created on or after this date and time (inclusive). |
+ **createdBefore** | **time.Time** | Filter test runs created before this date and time (non-inclusive). |
 
 ### Return type
 
@@ -416,9 +416,9 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	id := int64(789) // int64 | ID of the load test run.
-	patchTestRunApiModel := *openapiclient.NewPatchTestRunApiModel("Note_example") // PatchTestRunApiModel | 
+	patchTestRunApiModel := *openapiclient.NewPatchTestRunApiModel("Note_example") // PatchTestRunApiModel |
 
 	configuration := openapiclient.NewConfiguration()
 	apiClient := openapiclient.NewAPIClient(configuration)
@@ -436,7 +436,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**id** | **int64** | ID of the load test run. | 
+**id** | **int64** | ID of the load test run. |
 
 ### Other Parameters
 
@@ -445,9 +445,9 @@ Other parameters are passed through a pointer to a apiTestRunsPartialUpdateReque
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
- **patchTestRunApiModel** | [**PatchTestRunApiModel**](PatchTestRunApiModel.md) |  | 
+ **patchTestRunApiModel** | [**PatchTestRunApiModel**](PatchTestRunApiModel.md) |  |
 
 ### Return type
 
@@ -488,7 +488,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	id := int64(789) // int64 | ID of the load test run.
 
 	configuration := openapiclient.NewConfiguration()
@@ -509,7 +509,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**id** | **int64** | ID of the load test run. | 
+**id** | **int64** | ID of the load test run. |
 
 ### Other Parameters
 
@@ -518,7 +518,7 @@ Other parameters are passed through a pointer to a apiTestRunsRetrieveRequest st
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
 
 ### Return type
@@ -560,7 +560,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	id := int64(789) // int64 | ID of the load test run.
 
 	configuration := openapiclient.NewConfiguration()
@@ -579,7 +579,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**id** | **int64** | ID of the load test run. | 
+**id** | **int64** | ID of the load test run. |
 
 ### Other Parameters
 
@@ -588,7 +588,7 @@ Other parameters are passed through a pointer to a apiTestRunsSaveRequest struct
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
 
 ### Return type
@@ -630,7 +630,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	id := int64(789) // int64 | ID of the load test run.
 
 	configuration := openapiclient.NewConfiguration()
@@ -651,7 +651,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**id** | **int64** | ID of the load test run. | 
+**id** | **int64** | ID of the load test run. |
 
 ### Other Parameters
 
@@ -660,7 +660,7 @@ Other parameters are passed through a pointer to a apiTestRunsScriptRetrieveRequ
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
 
 ### Return type
@@ -702,7 +702,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	id := int64(789) // int64 | ID of the load test run.
 
 	configuration := openapiclient.NewConfiguration()
@@ -721,7 +721,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**id** | **int64** | ID of the load test run. | 
+**id** | **int64** | ID of the load test run. |
 
 ### Other Parameters
 
@@ -730,7 +730,7 @@ Other parameters are passed through a pointer to a apiTestRunsStarRequest struct
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
 
 ### Return type
@@ -772,7 +772,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	id := int64(789) // int64 | ID of the load test run.
 
 	configuration := openapiclient.NewConfiguration()
@@ -791,7 +791,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**id** | **int64** | ID of the load test run. | 
+**id** | **int64** | ID of the load test run. |
 
 ### Other Parameters
 
@@ -800,7 +800,7 @@ Other parameters are passed through a pointer to a apiTestRunsUnsaveRequest stru
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
 
 ### Return type
@@ -842,7 +842,7 @@ import (
 )
 
 func main() {
-	xStackId := int32(56) // int32 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
+	xStackId := int64(789) // int64 | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
 	id := int64(789) // int64 | ID of the load test run.
 
 	configuration := openapiclient.NewConfiguration()
@@ -861,7 +861,7 @@ func main() {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**id** | **int64** | ID of the load test run. | 
+**id** | **int64** | ID of the load test run. |
 
 ### Other Parameters
 
@@ -870,7 +870,7 @@ Other parameters are passed through a pointer to a apiTestRunsUnstarRequest stru
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **xStackId** | **int32** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. | 
+ **xStackId** | **int64** | Numeric ID of the Grafana stack representing the request scope. - If the API is called with a *Personal API token*, the user must be a member of the specified stack. - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack. |
 
 
 ### Return type

--- a/schema.yaml
+++ b/schema.yaml
@@ -5489,4 +5489,5 @@ components:
         - If the API is called with a *Grafana Stack API token*, the value must be the ID of the corresponding stack.
       schema:
         type: integer
+        format: int64
       required: true


### PR DESCRIPTION
## What

Adds `format: int64` to the shared `stackId` parameter component in `schema.yaml` and regenerates the client, widening the `XStackId` setter (and its backing struct field) from `int32` to `int64` across all ~50 operations that reference it.

## Why

Fixes #33. The recent regenerations (#29, #30) widened project ID, load test ID, test run ID, and `default_project_id` from `int32` to `int64`, but the `stackId` parameter block was never touched — leaving stack IDs as the only ID-shaped value still at 32 bits, despite scoping the very resources whose IDs were widened. The block had no `format` key, so openapi-generator defaulted it to `int32`.

## How

Since `stackId` is a single shared `$ref`'d component, the one-line schema edit propagates an `int64` `XStackId` setter to every operation automatically — no template changes needed. Regenerated with the pinned `openapi-generator-cli:v7.9.0` and `goimports`.

The diff is exactly the `int32`→`int64` widening for every `XStackId` setter and field; the touched `k6/docs/*API.md` files also had their (generator-produced) trailing whitespace stripped.

## Verification

- `go build ./...` passes for both the `k6` client and `examples`.

Fixes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)